### PR TITLE
feat: stream orchestrator events

### DIFF
--- a/api/live.html
+++ b/api/live.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<title>Flux d'exécution</title>
+<style>
+#chat {border:1px solid #ccc; padding:10px; height:300px; overflow-y:scroll;}
+</style>
+</head>
+<body>
+<h1>Flux d'exécution</h1>
+<div id="chat"></div>
+<script>
+const chat = document.getElementById('chat');
+const source = new EventSource('/events');
+source.onmessage = function(e) {
+  try {
+    const msg = JSON.parse(e.data);
+    const p = document.createElement('p');
+    p.textContent = `[${msg.type}] ${msg.agent || ''} ${msg.score !== undefined ? 'score: '+msg.score : ''} ${msg.sources ? 'sources: '+msg.sources.join(', ') : ''}`;
+    chat.appendChild(p);
+    chat.scrollTop = chat.scrollHeight;
+  } catch(err) {
+    console.error('Message invalide', err);
+  }
+};
+</script>
+</body>
+</html>

--- a/core/event_stream.py
+++ b/core/event_stream.py
@@ -1,0 +1,25 @@
+import asyncio
+import json
+
+listeners: list[asyncio.Queue] = []
+
+
+def register() -> asyncio.Queue:
+    queue: asyncio.Queue = asyncio.Queue()
+    listeners.append(queue)
+    return queue
+
+
+def unregister(queue: asyncio.Queue) -> None:
+    try:
+        listeners.remove(queue)
+    except ValueError:
+        pass
+
+
+async def broadcast(event: dict) -> None:
+    if not listeners:
+        return
+    data = json.dumps(event)
+    for queue in list(listeners):
+        await queue.put(data)


### PR DESCRIPTION
## Summary
- add server-sent events endpoint and simple live page
- broadcast orchestrator agent events to SSE stream
- implement shared event stream utility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68920cd1c0a483268d9d442100bb0952