### PR TITLE
Add unit tests and CI for agents

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest
+      - run: pytest -q

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_agent_extraction.py
+++ b/tests/test_agent_extraction.py
@@ -1,0 +1,33 @@
+import types
+import sys
+import importlib
+import asyncio
+
+
+def test_extraction_agent_run():
+    config_stub = types.ModuleType("core.config")
+    config_stub.settings = types.SimpleNamespace(OPENAI_API_KEY="key")
+    sys.modules["core.config"] = config_stub
+
+    extract_stub = types.ModuleType("pipelines.extract_entities")
+    extract_stub.extract_all_entities = lambda text, openai_api_key=None, fallback_llm=None, filter_result=True: {
+        "PER": ["Alice"],
+        "ORG": ["ACME"],
+        "montants": ["100 €"],
+        "dates": ["2023-01-01"],
+    }
+    sys.modules["pipelines.extract_entities"] = extract_stub
+
+    hybrid_stub = types.ModuleType("pipelines.hybrid_retrieval")
+    hybrid_stub.hybrid_search = lambda query, top_k=7: [{"text": "dummy", "rerank_score": 2.0}]
+    sys.modules["pipelines.hybrid_retrieval"] = hybrid_stub
+
+    import agents.agent_extraction as module
+    importlib.reload(module)
+    agent = module.ExtractionAgent()
+    assert agent.can_handle("Quel est le montant?", {})
+    context = {"sources": [{"text": "Alice a créé ACME le 2023-01-01 pour 100 €"}]}
+    result = asyncio.run(agent.run("question", context))
+    assert result["entities"]["PER"] == ["Alice"]
+    assert result["entities"]["ORG"] == ["ACME"]
+    assert "Alice" in result["answer"]

--- a/tests/test_agent_feedback.py
+++ b/tests/test_agent_feedback.py
@@ -1,0 +1,34 @@
+import types
+import sys
+import importlib
+import asyncio
+
+
+def test_feedback_agent_ok():
+    logging_stub = types.ModuleType("core.logging")
+    called = {}
+
+    def fake_log_feedback(answer_id, status, comment, user):
+        called["args"] = (answer_id, status, comment, user)
+
+    logging_stub.log_feedback = fake_log_feedback
+    sys.modules["core.logging"] = logging_stub
+
+    import agents.agent_feedback as module
+    importlib.reload(module)
+    agent = module.FeedbackAgent()
+    assert agent.can_handle("feedback:123:utile:Bon", {})
+    result = asyncio.run(agent.run("feedback:123:utile:Bon", {"user": "bob"}))
+    assert called["args"] == ("123", "utile", "Bon", "bob")
+    assert "123" in result["answer"]
+
+
+def test_feedback_agent_bad_format():
+    logging_stub = types.ModuleType("core.logging")
+    logging_stub.log_feedback = lambda *a, **k: None
+    sys.modules["core.logging"] = logging_stub
+    import agents.agent_feedback as module
+    importlib.reload(module)
+    agent = module.FeedbackAgent()
+    result = asyncio.run(agent.run("feedback:oops", {}))
+    assert "Format de feedback incorrect" in result["answer"]

--- a/tests/test_agent_n8n_webhook.py
+++ b/tests/test_agent_n8n_webhook.py
@@ -1,0 +1,22 @@
+import asyncio
+from agents.agent_n8n_webhook import N8NWebhookAgent
+
+
+def test_n8n_webhook_agent():
+    agent = N8NWebhookAgent()
+    assert agent.can_handle("__n8n_webhook__", {})
+    context = {
+        "payload": {
+            "entities": {"PER": ["Alice"]},
+            "sources": [{"id": 1}],
+            "actions": ["act"],
+            "answer": "done",
+            "extra": "x",
+        }
+    }
+    result = asyncio.run(agent.run("__n8n_webhook__", context))
+    assert result["status"] == "ok"
+    assert result["entities"] == {"PER": ["Alice"]}
+    assert result["actions"] == ["act"]
+    assert result["result"] == "done"
+    assert result["extra"] == {"extra": "x"}

--- a/tests/test_agent_search.py
+++ b/tests/test_agent_search.py
@@ -1,0 +1,31 @@
+import types
+import sys
+import importlib
+import asyncio
+
+
+def _setup_agent(score):
+    stub = types.ModuleType("pipelines.hybrid_retrieval")
+    stub.hybrid_search = lambda query, top_k=7: [{"text": "doc", "rerank_score": score}]
+    sys.modules["pipelines.hybrid_retrieval"] = stub
+    import agents.agent_search as module
+    importlib.reload(module)
+    return module.SearchAgent()
+
+
+def test_search_agent_success():
+    agent = _setup_agent(2.0)
+    ctx = {}
+    assert agent.can_handle("trouve moi", ctx)
+    result = asyncio.run(agent.run("question", ctx))
+    assert result["sources"][0]["text"] == "doc"
+    assert ctx["sources"]
+
+
+def test_search_agent_low_confidence():
+    agent = _setup_agent(0.5)
+    ctx = {}
+    result = asyncio.run(agent.run("question", ctx))
+    assert result["sources"] == []
+    assert ctx["sources"] == []
+    assert "Aucun passage" in result["answer"]

--- a/tests/test_agent_synthesis.py
+++ b/tests/test_agent_synthesis.py
@@ -1,0 +1,22 @@
+import types
+import sys
+import importlib
+import asyncio
+
+
+def test_synthesis_agent_run():
+    stub = types.ModuleType("pipelines.rag_chain")
+    stub.answer_with_rag = lambda question, top_k=5, user=None: {
+        "answer": "resp",
+        "sources": [{"text": "doc"}],
+        "entities": {}
+    }
+    sys.modules["pipelines.rag_chain"] = stub
+    import agents.agent_synthesis as module
+    importlib.reload(module)
+    agent = module.SynthesisAgent()
+    ctx = {}
+    assert agent.can_handle("any", ctx)
+    result = asyncio.run(agent.run("question", ctx))
+    assert result["answer"] == "resp"
+    assert ctx["sources"] == [{"text": "doc"}]

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -1,0 +1,35 @@
+from core.context_manager import ContextManager
+
+
+def test_context_manager_operations():
+    cm = ContextManager()
+    ctx = cm.get("s1", "q1")
+    assert ctx["history"] == ["q1"]
+
+    cm.set_entity("s1", "person", ["Alice"])
+    cm.add_entities("s1", {"person": ["Bob"], "org": ["Acme"]})
+    entities = cm.get("s1")["entities"]
+    assert sorted(entities["person"]) == ["Alice", "Bob"]
+    assert entities["org"] == ["Acme"]
+
+    cm.clear_entities("s1")
+    assert cm.get("s1")["entities"] == {}
+
+    cm.add_context_summary("s1", "summary1")
+    assert cm.get_context_summaries("s1") == ["summary1"]
+
+    cm.set_var("s1", "flag", True)
+    assert cm.get_var("s1", "flag") is True
+    assert cm.get_var("s1", "missing", "def") == "def"
+
+    sources = [{"text": "doc1"}]
+    cm.set_sources("s1", sources)
+    assert cm.get_sources("s1") == sources
+    cm.clear_sources("s1")
+    assert cm.get_sources("s1") == []
+
+    cm.set_full_document_text("s1", "full text")
+    assert cm.get_full_document_text("s1") == "full text"
+
+    cm.clear("s1")
+    assert "s1" not in cm.sessions


### PR DESCRIPTION
## Summary
- add pytest-based tests covering ContextManager and all available agents
- configure GitHub Actions workflow to run pytest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68920cb48ef883268a4926b257b950a1