### PR TITLE
refactor: replace prints with logging

### DIFF
--- a/core/logging.py
+++ b/core/logging.py
@@ -4,6 +4,18 @@ from datetime import datetime
 import logging
 from functools import wraps
 
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+LOG_FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format=LOG_FORMAT,
+)
+
+
+def get_logger(name: str = __name__) -> logging.Logger:
+    """Return a logger configured for this application."""
+    return logging.getLogger(name)
+
 # --- CSV LOGGING CLASSIQUE ---
 
 LOGS_DIR = os.path.join(os.path.dirname(__file__), "../logs")
@@ -53,8 +65,8 @@ def log_interaction(session_id, question, answer, agent, user=None, entities=Non
 # --- LOGGER API (requests.log) ---
 
 api_logger = logging.getLogger("sma_api_logger")
-api_logger.setLevel(logging.INFO)
-formatter = logging.Formatter('%(asctime)s | %(levelname)s | %(message)s')
+api_logger.setLevel(getattr(logging, LOG_LEVEL, logging.INFO))
+formatter = logging.Formatter(LOG_FORMAT)
 file_handler = logging.FileHandler(REQUESTS_LOG)
 file_handler.setFormatter(formatter)
 if not api_logger.handlers:

--- a/detect_non_utf8.py
+++ b/detect_non_utf8.py
@@ -1,4 +1,8 @@
 import os
+import logging
+from core.logging import get_logger
+
+logger = get_logger(__name__)
 
 root = "C:/Users/grego/Desktop/Dossiers/DisruptIQ/Codes/SSMA"
 non_utf8_files = []
@@ -13,6 +17,6 @@ for dirpath, _, filenames in os.walk(root):
             except UnicodeDecodeError:
                 non_utf8_files.append(filepath)
 
-print("Fichiers non UTF-8 :")
+logger.info("Fichiers non UTF-8 :")
 for f in non_utf8_files:
-    print(f)
+    logger.info(f)

--- a/pipelines/build_whoosh_index.py
+++ b/pipelines/build_whoosh_index.py
@@ -1,5 +1,7 @@
 ﻿import sys
 import os
+import logging
+from core.logging import get_logger
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from whoosh.fields import Schema, TEXT, ID
@@ -8,6 +10,8 @@ from qdrant_client import QdrantClient
 from langchain_qdrant import Qdrant
 from langchain_huggingface import HuggingFaceEmbeddings
 from core.config import settings
+
+logger = get_logger(__name__)
 
 INDEX_DIR = os.path.join(os.path.dirname(__file__), "../whoosh_index")
 
@@ -37,11 +41,11 @@ def build_index():
 
     writer = ix.writer()
     docs = get_all_docs_from_qdrant()
-    print(f"Indexation Whoosh de {len(docs)} passages...")
+    logger.info("Indexation Whoosh de %d passages...", len(docs))
     for idx, doc in enumerate(docs):
         writer.add_document(id=str(idx), content=doc.page_content)
     writer.commit()
-    print("âœ… Index Whoosh crÃ©Ã©/mis Ã  jour.")
+    logger.info("✅ Index Whoosh créé/mis à jour.")
 
 if __name__ == "__main__":
     build_index()

--- a/pipelines/check_qdrant_content.py
+++ b/pipelines/check_qdrant_content.py
@@ -1,4 +1,8 @@
-﻿from qdrant_client import QdrantClient
+﻿import logging
+from core.logging import get_logger
+from qdrant_client import QdrantClient
+
+logger = get_logger(__name__)
 
 QDRANT_URL = "http://localhost:6333"
 QDRANT_COLLECTION = "docs"
@@ -6,9 +10,9 @@ QDRANT_COLLECTION = "docs"
 client = QdrantClient(QDRANT_URL)
 res = client.scroll(collection_name=QDRANT_COLLECTION, limit=5)
 for doc in res[0]:
-    print("---")
-    print(doc.payload.get("page_content", "NO CONTENT"))
-    print(doc.payload)
+    logger.info("---")
+    logger.info(doc.payload.get("page_content", "NO CONTENT"))
+    logger.info(doc.payload)
 
 
 

--- a/pipelines/rag_chain.py
+++ b/pipelines/rag_chain.py
@@ -1,6 +1,7 @@
 ﻿# pipelines/rag_chain.py
 
 import logging
+from core.logging import get_logger
 from qdrant_client import QdrantClient
 from langchain_qdrant import Qdrant  # Remplace l'ancien import deprecated
 from langchain_huggingface import HuggingFaceEmbeddings
@@ -9,6 +10,8 @@ from langchain.chains import RetrievalQA
 from langchain.prompts import PromptTemplate
 
 from core.config import settings
+
+logger = get_logger(__name__)
 
 def get_embeddings():
     return HuggingFaceEmbeddings(model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
@@ -88,11 +91,11 @@ def answer_with_rag(question: str, top_k: int = 8, user: str = None) -> dict:
     # Selon ta version de langchain-core, tu peux utiliser invoke() (synchrone) ou ainvoke() (async)
     retrieved_docs = retriever.invoke(question)
 
-    print("\n=== Chunks retrouvÃ©s pour la question:", question)
+    logger.debug("\n=== Chunks retrouvés pour la question: %s", question)
     if not retrieved_docs:
-        print("!!! Aucun chunk retrouvÃ©")
+        logger.debug("!!! Aucun chunk retrouvé")
     for doc in retrieved_docs:
-        print("---", doc.page_content[:200])
+        logger.debug("--- %s", doc.page_content[:200])
 
     if not settings.OPENAI_API_KEY:
         return {"answer": "", "sources": [], "entities": {}, "error": "OPENAI_API_KEY non configurÃ©e"}
@@ -103,8 +106,8 @@ def answer_with_rag(question: str, top_k: int = 8, user: str = None) -> dict:
 
     # Affiche le prompt rÃ©el (simulateur "ce que voit le LLM")
     ctx_concat = "\n".join([d.page_content for d in retrieved_docs])
-    print("\n=== PROMPT FINAL ENVOYÃ‰ AU LLM ===")
-    print(prompt.format(context=ctx_concat, question=question))
+    logger.debug("\n=== PROMPT FINAL ENVOYÉ AU LLM ===")
+    logger.debug(prompt.format(context=ctx_concat, question=question))
 
     llm = OpenAI(temperature=0, openai_api_key=settings.OPENAI_API_KEY)
     qa = RetrievalQA.from_chain_type(
@@ -115,21 +118,21 @@ def answer_with_rag(question: str, top_k: int = 8, user: str = None) -> dict:
     )
     result = qa({"query": question})
 
-    print("\n=== RAW RESULT DE LLM ===")
-    print(result)
+    logger.debug("\n=== RAW RESULT DE LLM ===")
+    logger.debug(result)
 
     # SÃ©curitÃ©Â : vÃ©rifie la prÃ©sence de "result" (peut varier selon version)
     answer = result.get("result", "")
     docs = result.get("source_documents", [])
 
     # DEBUGÂ : affiche le contexte passÃ© effectivement au LLM (source_documents)
-    print("\n=== CONTEXT EFFECTIVEMENT PASSE AU LLM ===")
+    logger.debug("\n=== CONTEXT EFFECTIVEMENT PASSE AU LLM ===")
     for d in docs:
-        print(d.page_content[:400])
+        logger.debug(d.page_content[:400])
 
     # --- format de sortie basique ---
     sources = [{"text": d.page_content, "metadata": d.metadata} for d in docs]
-    logging.info(f"RAG >> question={question} answer={answer[:60]}...")
+    logger.info("RAG >> question=%s answer=%s...", question, answer[:60])
     return {"answer": answer, "sources": sources, "entities": {}}
 
 

--- a/pipelines/reset_all.py
+++ b/pipelines/reset_all.py
@@ -1,6 +1,10 @@
-﻿import os
+import os
 import shutil
+import logging
+from core.logging import get_logger
 from qdrant_client import QdrantClient
+
+logger = get_logger(__name__)
 
 # === 1. RESET QDRANT ===
 QDRANT_URL = "http://localhost:6333"
@@ -9,9 +13,9 @@ QDRANT_COLLECTION = "docs"
 client = QdrantClient(QDRANT_URL)
 try:
     client.delete_collection(collection_name=QDRANT_COLLECTION)
-    print(f"âœ… Collection Qdrant '{QDRANT_COLLECTION}' supprimÃ©e !")
+    logger.info("✅ Collection Qdrant '%s' supprimée !", QDRANT_COLLECTION)
 except Exception as e:
-    print(f"âš ï¸ Impossible de supprimer la collection QdrantÂ : {e}")
+    logger.error("⚠️ Impossible de supprimer la collection Qdrant : %s", e)
 
 # === 2. RESET WHOOSH ===
 WHOOSH_INDEX_DIR = os.path.join(os.path.dirname(__file__), "../whoosh_index")
@@ -20,13 +24,10 @@ whoosh_dir = os.path.abspath(WHOOSH_INDEX_DIR)
 if os.path.isdir(whoosh_dir):
     try:
         shutil.rmtree(whoosh_dir)
-        print(f"âœ… Dossier Whoosh index '{whoosh_dir}' supprimÃ© !")
+        logger.info("✅ Dossier Whoosh index '%s' supprimé !", whoosh_dir)
     except Exception as e:
-        print(f"âš ï¸ Impossible de supprimer l'index WhooshÂ : {e}")
+        logger.error("⚠️ Impossible de supprimer l'index Whoosh : %s", e)
 else:
-    print(f"â„¹ï¸ Dossier Whoosh index '{whoosh_dir}' inexistant (dÃ©jÃ  clean)")
+    logger.info("ℹ️ Dossier Whoosh index '%s' inexistant (déjà clean)", whoosh_dir)
 
-print("\nðŸŽ¯ RESET ALL terminÃ©. Tu peux relancer tes imports !")
-
-
-
+logger.info("\n🎯 RESET ALL terminé. Tu peux relancer tes imports !")

--- a/pipelines/reset_qdrant.py
+++ b/pipelines/reset_qdrant.py
@@ -1,5 +1,9 @@
+import logging
+from core.logging import get_logger
 from qdrant_client import QdrantClient
+
+logger = get_logger(__name__)
 
 client = QdrantClient("http://localhost:6333")
 client.delete_collection(collection_name="docs")
-print("✅ Collection Qdrant 'docs' supprimée !")
+logger.info("✅ Collection Qdrant 'docs' supprimée !")

--- a/scripts/batch_index_folder.py
+++ b/scripts/batch_index_folder.py
@@ -1,5 +1,6 @@
 ﻿import os
 import logging
+from core.logging import get_logger
 from core.file_parser import extract_text_and_metadata
 from pipelines.vectorize import store_text_in_qdrant  # Adapté à ta brique vectorisation
 import time
@@ -13,11 +14,10 @@ SUPPORTED_EXT = {"pdf", "docx", "doc", "txt", "xlsx", "xls", "png", "jpg", "jpeg
 
 os.makedirs("logs", exist_ok=True)
 
-logging.basicConfig(
-    filename=LOG_FILE,
-    level=logging.INFO,
-    format='%(asctime)s [%(levelname)s] %(message)s'
-)
+logger = get_logger(__name__)
+file_handler = logging.FileHandler(LOG_FILE)
+file_handler.setFormatter(logging.Formatter('%(asctime)s [%(levelname)s] %(message)s'))
+logger.addHandler(file_handler)
 
 def process_file(path):
     filename = os.path.basename(path)
@@ -42,30 +42,30 @@ def main():
             path = os.path.join(root, file)
             total += 1
             try:
-                logging.info(f"Indexation de : {path}")
+                logger.info("Indexation de : %s", path)
                 nb_chunks, meta = process_file(path)
                 with open(SUCCESS_LOG, "a", encoding="utf-8") as sl:
                     sl.write(f"{file},{meta['ext']},{nb_chunks}\n")
-                logging.info(f"SUCCESS: {file} ({meta['ext']}) -> {nb_chunks} chunks.")
+                logger.info("SUCCESS: %s (%s) -> %d chunks.", file, meta['ext'], nb_chunks)
                 success += 1
                 results.append((file, meta['ext'], nb_chunks))
             except Exception as e:
                 with open(ERROR_LOG, "a", encoding="utf-8") as el:
                     el.write(f"{file},{ext},ERROR,\"{str(e)}\"\n")
-                logging.error(f"FAIL: {file} ({ext}) : {e}")
+                logger.error("FAIL: %s (%s) : %s", file, ext, e)
                 failed += 1
                 errors.append((file, ext, str(e)))
 
     # Rapport final
-    print(f"\nIndexation terminée : {success}/{total} fichiers OK, {failed} erreurs.")
-    print(f"Voir : {LOG_FILE}, {SUCCESS_LOG}, {ERROR_LOG}")
+    logger.info("\nIndexation terminée : %d/%d fichiers OK, %d erreurs.", success, total, failed)
+    logger.info("Voir : %s, %s, %s", LOG_FILE, SUCCESS_LOG, ERROR_LOG)
     if failed:
-        print(f"Fichiers en erreur : {[e[0] for e in errors]}")
+        logger.info("Fichiers en erreur : %s", [e[0] for e in errors])
     else:
-        print("Aucune erreur.")
+        logger.info("Aucune erreur.")
     # Possibilité d’envoyer un rapport par email/n8n ici
 
 if __name__ == "__main__":
     t0 = time.time()
     main()
-    print(f"Temps total : {time.time() - t0:.1f} sec")
+    logger.info("Temps total : %.1f sec", time.time() - t0)

--- a/scripts/hotfolder_watcher.py
+++ b/scripts/hotfolder_watcher.py
@@ -2,6 +2,7 @@
 import os
 import time
 import logging
+from core.logging import get_logger
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 from core.file_parser import extract_text_and_metadata
@@ -17,12 +18,10 @@ os.makedirs(WATCH_DIR, exist_ok=True)
 os.makedirs(PROCESSED_DIR, exist_ok=True)
 
 # ENCODING UTF-8 pour les logs !
-logging.basicConfig(
-    filename=LOG_FILE,
-    level=logging.INFO,
-    format='%(asctime)s [%(levelname)s] %(message)s',
-    encoding='utf-8'
-)
+logger = get_logger(__name__)
+file_handler = logging.FileHandler(LOG_FILE, encoding='utf-8')
+file_handler.setFormatter(logging.Formatter('%(asctime)s [%(levelname)s] %(message)s'))
+logger.addHandler(file_handler)
 
 def safe_move(src, dst):
     base, ext = os.path.splitext(dst)
@@ -35,7 +34,7 @@ def safe_move(src, dst):
 def process_file(path):
     filename = os.path.basename(path)
     if "INDEXED_" in filename or "/processed/" in path.replace("\\", "/"):
-        logging.info(f"Ignoré (déjà traité) : {path}")
+        logger.info("Ignoré (déjà traité) : %s", path)
         return
 
     try:
@@ -45,15 +44,15 @@ def process_file(path):
         if not text or not text.strip():
             raise ValueError("Texte vide ou extraction impossible.")
         nb_chunks = store_text_in_qdrant(text, metadata=meta)
-        logging.info(f"✅ {filename} ({meta['ext']}) importé ({nb_chunks} chunks)")
+        logger.info("✅ %s (%s) importé (%d chunks)", filename, meta['ext'], nb_chunks)
 
         new_filename = f"INDEXED_{filename}"
         new_path = os.path.join(PROCESSED_DIR, new_filename)
         safe_move(path, new_path)
-        logging.info(f"Déplacé et renommé : {new_path}")
+        logger.info("Déplacé et renommé : %s", new_path)
 
     except Exception as e:
-        logging.error(f"Erreur import {path} : {e}")
+        logger.error("Erreur import %s : %s", path, e)
 
 class WatcherHandler(FileSystemEventHandler):
     def on_moved(self, event):
@@ -67,20 +66,20 @@ class WatcherHandler(FileSystemEventHandler):
             return
         ext = filename.split(".")[-1].lower()
         if ext not in SUPPORTED_EXT:
-            logging.info(f"Ignoré (format non supporté) : {event.src_path}")
+            logger.info("Ignoré (format non supporté) : %s", event.src_path)
             return
         try:
-            logging.info(f"Détection nouveau fichier : {event.src_path}")
+            logger.info("Détection nouveau fichier : %s", event.src_path)
             time.sleep(1.0)
             process_file(event.src_path)
         except Exception as e:
-            logging.error(f"Erreur process_file sur {event.src_path} : {e}")
+            logger.error("Erreur process_file sur %s : %s", event.src_path, e)
 
 if __name__ == "__main__":
     observer = Observer()
     event_handler = WatcherHandler()
     observer.schedule(event_handler, WATCH_DIR, recursive=True)
-    print(f"👋  Watcher actif sur : {os.path.abspath(WATCH_DIR)}\nDéposez des fichiers, ils seront indexés, renommés et déplacés dans /processed/ automatiquement !")
+    logger.info("👋  Watcher actif sur : %s\nDéposez des fichiers, ils seront indexés, renommés et déplacés dans /processed/ automatiquement !", os.path.abspath(WATCH_DIR))
     observer.start()
     try:
         while True:

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,11 +1,15 @@
 ﻿# scripts/ingest.py
 import sys
+import logging
+from core.logging import get_logger
 from qdrant_client import QdrantClient
 from qdrant_client.http.models import Distance, VectorParams
 from langchain_community.vectorstores import Qdrant
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.schema import Document
+
+logger = get_logger(__name__)
 
 # Configuration Qdrantâ€‰â€“â€‰vous pouvez aussi importer core.config.settings
 QDRANT_URL = "http://localhost:6333"
@@ -41,18 +45,18 @@ def ingest_text(text: str, metadata: dict = {}):
     # Ajouter les docs
     vectorstore = Qdrant(client=client, collection_name=COLLECTION, embeddings=get_embeddings())
     vectorstore.add_documents(docs)
-    print(f"Ingested {len(docs)} chunks into '{COLLECTION}'.")
+    logger.info("Ingested %d chunks into '%s'.", len(docs), COLLECTION)
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: python ingest.py path/to/file.txt")
+        logger.info("Usage: python ingest.py path/to/file.txt")
         sys.exit(1)
     path = sys.argv[1]
     try:
         with open(path, encoding="utf-8") as f:
             raw = f.read()
     except Exception as e:
-        print(f"Error reading {path}: {e}")
+        logger.error("Error reading %s: %s", path, e)
         sys.exit(1)
 
     ingest_text(raw, {"source": path})


### PR DESCRIPTION
## Summary
- centralize logging with environment configurable levels
- swap print statements for logger calls across scripts and pipelines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68920cafa1708326873198f7798882fd