### PR TITLE
Add re import for regex entity extraction

### DIFF
--- a/pipelines/extract_entities.py
+++ b/pipelines/extract_entities.py
@@ -1,6 +1,6 @@
+import langdetect
 import re
 import spacy
-import langdetect
 
 # ========================
 # Chargement des modÃ¨les spaCy
@@ -99,7 +99,6 @@ def fallback_llm_extract_persons(text, openai_api_key):
         temperature=0
     )
     import json
-    import re
     answer = response.choices[0].message.content
     try:
         match = re.search(r'\{.*\}', answer, re.DOTALL)


### PR DESCRIPTION
## Summary
- ensure `re` is imported at module level for regex-based entity extraction
- remove redundant local `re` import in fallback function

## Testing
- `pytest -q`
- `python - <<'PY'
import types, sys
sys.modules['langdetect'] = types.SimpleNamespace(detect=lambda text: 'en')
spacy_stub = types.SimpleNamespace(load=lambda name: None)
sys.modules['spacy'] = spacy_stub
from pipelines.extract_entities import extract_montants, extract_dates
print(extract_montants('Il a gagné 1 000 € et $200.'))
print(extract_dates('Nous sommes le 31/12/2020 et 01-01-2021.'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68922500fe5c8326a9edf12071884498